### PR TITLE
Remove free support forums paragraph from help tab

### DIFF
--- a/templates/bsr-help.php
+++ b/templates/bsr-help.php
@@ -32,14 +32,6 @@ $bsr_support_url = 'https://wordpress.org/support/plugin/better-search-replace';
 					<p>
 						<?php
 						printf(
-							__( 'Free support is available on the <a href="%s">plugin support forums</a>.', 'better-search-replace' ),
-							$bsr_support_url
-						)
-						?>
-					</p>
-					<p>
-						<?php
-						printf(
 							__( '<a href="%s" style="font-weight:bold;" target="_blank">Upgrade</a> to gain access to premium features and priority email support.', 'better-search-replace' ),
 							'https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=help-tab&utm_campaign=bsr-to-migrate'
 						);


### PR DESCRIPTION
This PR resolves [DELI-1165](https://wpengine.atlassian.net/browse/DELI-1165).

## Description

Remove free support text (`Free support is available on the plugin support forums.`) from the help page

## Testing Checklist
- [ ] Does this PR require Multisite testing?
- [ ] Does this PR require CLI testing?

## Pre-review Checklist
- [x] Jira ticket and PR titles are correctly formatted.
- [x] Acceptance criteria from the Jira ticket have been satisfied.
- [x] Changelog updated in readme(s) (if applicable).
- [ ] [Documentation issue](https://github.com/deliciousbrains/wp-migrate-db-pro/issues/new?assignees=&labels=Documentation&template=05-documentation.md&title=Documentation+of+X+should+%28not%29...) has been created (if docs need updated).
- [ ] Unit tests are included (if applicable).
- [x] Self-review of code changes has been completed.
- [x] Self-review of UX changes has been completed.
- [x] Review has been requested from team member(s).
- [x] GitHub Label has been selected for this PR.

[DELI-1165]: https://wpengine.atlassian.net/browse/DELI-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ