### PR TITLE
Resolve issues picked up within PCP tests

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 === Better Search Replace ===
 Contributors: wpengine, deliciousbrains, mattshaw
 Tags: search replace, search and replace, search replace database, update database urls, update live url
-Requires at least: 3.0.1
+Requires at least: 6.2
 Tested up to: 6.9
 Stable tag: 1.4.10
 License: GPLv3 or later

--- a/assets/js/better-search-replace.js
+++ b/assets/js/better-search-replace.js
@@ -7,6 +7,17 @@
 	function bsr_init() {
 		bsr_search_replace();
 		bsr_update_sliders();
+		bsr_thickbox_fix();
+	}
+
+	/**
+	 * Builds the custom admin URL with a valid bsr-ajax query value.
+	 *
+	 * @param {string} action Admin action to be passed as a query arg to endpoint.
+	 */
+	function bsr_ajax_url( action ) {
+		var base = bsr_object_vars.endpoint;
+		return base + ( base.indexOf( '?' ) !== -1 ? '&' : '?' ) + 'bsr-ajax=' + encodeURIComponent( action );
 	}
 
 	/**
@@ -16,7 +27,7 @@
 
 		$.ajax({
 			type: 'POST',
-			url: bsr_object_vars.endpoint + action,
+			url: bsr_ajax_url( action ),
 			data: {
 				bsr_ajax_nonce : bsr_object_vars.ajax_nonce,
 				action: action,
@@ -30,7 +41,7 @@
 				// Maybe display more details.
 				if ( typeof response.message != 'undefined' ) {
 					$('.bsr-description').remove();
-					$('.bsr-progress-wrap').append( '<p class="description bsr-description">' + response.message + '</p>' );
+					$( '<p class="description bsr-description"></p>' ).text( response.message ).appendTo( '.bsr-progress-wrap' );
 				}
 
 				if ( 'done' == response.step ) {
@@ -124,6 +135,44 @@
 				$('#bsr-page-size-value').text( ui.value );
 				$('#bsr_page_size').val( ui.value );
 			}
+		});
+	}
+
+	/**
+	 * Fixes the Thickbox iframe src truncation.
+	 *
+	 * Core thickbox.js truncates iframe src at the substring "TB_"; this restores the full URL when action=bsr_view_details.
+	 */
+	function bsr_thickbox_fix() {
+		document.addEventListener('DOMContentLoaded', function() {
+			if ( typeof window.tb_show !== 'function' ) {
+				return;
+			}
+
+			var origTbShow = window.tb_show;
+
+			window.tb_show = function ( caption, url, imageGroup ) {
+				origTbShow.call( this, caption, url, imageGroup );
+
+				if ( typeof url !== 'string' || url.indexOf( 'action=bsr_view_details' ) === -1 ) {
+					return;
+				}
+
+				var applySrc = function () {
+					var el = document.getElementById( 'TB_iframeContent' );
+					if ( el ) {
+						el.setAttribute( 'src', url );
+					}
+				};
+
+				if ( window.requestAnimationFrame ) {
+					window.requestAnimationFrame( function () {
+						window.requestAnimationFrame( applySrc );
+					} );
+				} else {
+					window.setTimeout( applySrc, 0 );
+				}
+			};
 		});
 	}
 

--- a/better-search-replace.php
+++ b/better-search-replace.php
@@ -22,6 +22,7 @@
  * Text Domain:       better-search-replace
  * Domain Path:       /languages
  * Network:           true
+ * Requires at least: 6.2
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,6 +39,10 @@
  */
 
 // If this file was called directly, abort.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! defined( 'WPINC' ) ) {
 	die;
 }
@@ -67,6 +72,7 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	 *
 	 * @since 1.0.0
 	 */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Bootstrap entry; guarded by function_exists in bootstrap.
 	function run_better_search_replace() {
 		if ( bsr_enabled_for_user() ) {
 			/**
@@ -88,8 +94,10 @@ if ( ! function_exists( 'bsr_enabled_for_user' ) ) {
 	 *
 	 * @return bool
 	 */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Public helper; guarded by function_exists in bootstrap.
 	function bsr_enabled_for_user() {
 		// Allows for overriding the capability required to run the plugin.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Legacy filter name; public API for capability override.
 		$cap = apply_filters( 'bsr_capability', 'manage_options' );
 
 		return current_user_can( $cap );

--- a/ext/bsr-ext-functions.php
+++ b/ext/bsr-ext-functions.php
@@ -1,9 +1,14 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! function_exists( 'bsr_check_for_upgrades' ) ) {
 	/**
 	 * Initialize the checking for plugin updates.
 	 */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Dev-only ext; not shipped to WordPress.org trunk.
 	function bsr_check_for_upgrades() {
 		$properties = array(
 			'plugin_slug'     => 'better-search-replace',

--- a/includes/class-bsr-admin.php
+++ b/includes/class-bsr-admin.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * The dashboard-specific functionality of the plugin.
  *
@@ -83,6 +87,7 @@ class BSR_Admin {
 	 * @access public
 	 */
 	public function bsr_menu_pages() {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Legacy filter name; public API for capability override.
 		$cap = apply_filters( 'bsr_capability', 'manage_options' );
 		add_submenu_page( 'tools.php', __( 'Better Search Replace', 'better-search-replace' ), __( 'Better Search Replace', 'better-search-replace' ), $cap, 'better-search-replace', array( $this, 'bsr_menu_pages_callback' ) );
 	}
@@ -100,11 +105,13 @@ class BSR_Admin {
 	 * Renders the result or error onto the better-search-replace admin page.
 	 */
 	public static function render_result() {
-		// Trying to show results?
-		if ( ! isset( $_GET['result'] ) ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Each GET branch calls BSR_Utils::validate_tools_screen_get() before use.
+		if ( ! filter_has_var( INPUT_GET, 'result' ) || ! BSR_Utils::validate_tools_screen_get() ) {
+			// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 		$result = get_transient( 'bsr_results' );
 
 		// Have results with required fields set with correctly typed data?
@@ -120,31 +127,58 @@ class BSR_Admin {
 			return;
 		}
 
+		// TB_iframe is required for Thickbox iframe mode. Core thickbox truncates src at "TB_"; bsr_thickbox_fix() in assets/js/better-search-replace.js restores the full URL for action=bsr_view_details only.
+		$details_url = self::get_view_details_url(
+			array(
+				'TB_iframe' => 'true',
+				'width'     => '800',
+				'height'    => '500',
+			)
+		);
+
+		$result_message_allowed_html = array(
+			'p'      => array(),
+			'strong' => array(),
+			'a'      => array(
+				'href'  => true,
+				'class' => true,
+				'title' => true,
+			),
+		);
+
+		echo '<div class="updated bsr-updated" style="display: none;">';
+
 		if ( isset( $result['dry_run'] ) && $result['dry_run'] === 'on' ) {
 			$msg = sprintf(
+				/* translators: 1: number of tables, 2: cells found, 3: changes made, 4: details URL, 5: Thickbox title attribute. */
 				__(
-					'<p><strong>DRY RUN:</strong> <strong>%1$d</strong> tables were searched, <strong>%2$d</strong> cells were found that need to be updated, and <strong>%3$d</strong> changes were made.</p><p><a href="%4$s" class="thickbox" title="Dry Run Details">Click here</a> for more details, or use the form below to run the search/replace.</p>',
+					'<p><strong>DRY RUN:</strong> <strong>%1$d</strong> tables were searched, <strong>%2$d</strong> cells were found that need to be updated, and <strong>%3$d</strong> changes were made.</p><p><a href="%4$s" class="thickbox" title="%5$s">Click here</a> for more details, or use the form below to run the search/replace.</p>',
 					'better-search-replace'
 				),
-				$result['tables'],
-				$result['change'],
-				$result['updates'],
-				get_admin_url() . 'admin-post.php?action=bsr_view_details&TB_iframe=true&width=800&height=500'
+				(int) $result['tables'],
+				(int) $result['change'],
+				(int) $result['updates'],
+				esc_url( $details_url ),
+				esc_attr__( 'Dry Run Details', 'better-search-replace' )
 			);
+			echo wp_kses( $msg, $result_message_allowed_html );
 		} else {
 			$msg = sprintf(
+				/* translators: 1: tables searched, 2: cells changed, 3: updates, 4: details URL, 5: Thickbox title attribute. */
 				__(
-					'<p>During the search/replace, <strong>%1$d</strong> tables were searched, with <strong>%2$d</strong> cells changed in <strong>%3$d</strong> updates.</p><p><a href="%4$s" class="thickbox" title="Search/Replace Details">Click here</a> for more details.</p>',
+					'<p>During the search/replace, <strong>%1$d</strong> tables were searched, with <strong>%2$d</strong> cells changed in <strong>%3$d</strong> updates.</p><p><a href="%4$s" class="thickbox" title="%5$s">Click here</a> for more details.</p>',
 					'better-search-replace'
 				),
-				$result['tables'],
-				$result['change'],
-				$result['updates'],
-				get_admin_url() . 'admin-post.php?action=bsr_view_details&TB_iframe=true&width=800&height=500'
+				(int) $result['tables'],
+				(int) $result['change'],
+				(int) $result['updates'],
+				esc_url( $details_url ),
+				esc_attr__( 'Search/Replace Details', 'better-search-replace' )
 			);
+			echo wp_kses( $msg, $result_message_allowed_html );
 		}
 
-		echo '<div class="updated bsr-updated" style="display: none;">' . $msg . '</div>';
+		echo '</div>';
 	}
 
 	/**
@@ -155,24 +189,28 @@ class BSR_Admin {
 	 */
 	public static function prefill_value( $value, $type = 'text' ) {
 
-		// Grab the correct data to prefill.
-		if ( isset( $_GET['result'] ) && get_transient( 'bsr_results' ) ) {
+		if ( ! BSR_Utils::validate_tools_screen_get() ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Tools GET gated by BSR_Utils::validate_tools_screen_get().
+		if ( filter_has_var( INPUT_GET, 'result' ) && get_transient( 'bsr_results' ) ) {
 			$values = get_transient( 'bsr_results' );
 		} else {
 			$values = array();
 		}
 
 		// Prefill the value.
-		if ( isset( $values[$value] ) ) {
+		if ( isset( $values[ $value ] ) ) {
 
-			if ( 'checkbox' === $type && 'on' === $values[$value] ) {
+			if ( 'checkbox' === $type && 'on' === $values[ $value ] ) {
 				echo 'checked';
 			} else {
-				echo str_replace( '#BSR_BACKSLASH#', '\\', esc_attr( htmlentities( $values[$value] ) ) );
+				echo esc_attr( str_replace( '#BSR_BACKSLASH#', '\\', $values[ $value ] ) );
 			}
-
 		}
 
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -182,35 +220,62 @@ class BSR_Admin {
 	 */
 	public static function load_tables() {
 
-		// Get the tables and their sizes.
-		$tables 	= BSR_DB::get_tables();
-		$sizes 		= BSR_DB::get_sizes();
+		if ( ! BSR_Utils::validate_tools_screen_get() ) {
+			echo '<select id="bsr-table-select" name="select_tables[]" multiple="multiple" style=""></select>';
+			return;
+		}
+
+		$tables = BSR_DB::get_tables();
+		$sizes  = BSR_DB::get_sizes();
 
 		echo '<select id="bsr-table-select" name="select_tables[]" multiple="multiple" style="">';
 
+		$result           = null;
+		$transient_result = get_transient( 'bsr_results' );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Tools GET gated by BSR_Utils::validate_tools_screen_get().
+		if ( filter_has_var( INPUT_GET, 'result' ) && $transient_result ) {
+			$result = $transient_result;
+		}
+
 		foreach ( $tables as $table ) {
 
-			// Try to get the size for this specific table.
-			$table_size = isset( $sizes[$table] ) ? $sizes[$table] : '';
+			$table_size = isset( $sizes[ $table ] ) ? $sizes[ $table ] : '';
+			$selected   = false;
 
-			if ( isset( $_GET['result'] ) && get_transient( 'bsr_results' ) ) {
-
-				$result = get_transient( 'bsr_results' );
-
-				if ( isset( $result['table_reports'][$table] ) ) {
-					echo "<option value='$table' selected>$table $table_size</option>";
-				} else {
-					echo "<option value='$table'>$table $table_size</option>";
-				}
-
-			} else {
-				echo "<option value='$table'>$table $table_size</option>";
+			if ( is_array( $result ) && isset( $result['table_reports'][ $table ] ) ) {
+				$selected = true;
 			}
 
+			printf(
+				'<option value="%1$s"%2$s>%3$s</option>',
+				esc_attr( $table ),
+				$selected ? ' selected="selected"' : '',
+				esc_html( $table . ' ' . $table_size )
+			);
 		}
 
 		echo '</select>';
 
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * admin-post.php URL for bsr_view_details with nonce.
+	 *
+	 * For Thickbox iframe links you may pass TB_iframe=true (and width/height). Core thickbox.js
+	 * truncates iframe src at the substring "TB_"; bsr_thickbox_fix() in assets/js/better-search-replace.js
+	 * restores the full URL when action=bsr_view_details. Do not add other query keys whose names
+	 * contain "TB_".
+	 *
+	 * @param array $extra Query arguments (action is set automatically; _wpnonce is always appended last).
+	 * @return string Raw URL; use esc_url() when printing in HTML.
+	 */
+	public static function get_view_details_url( $extra = array() ) {
+		$args = array_merge( array( 'action' => 'bsr_view_details' ), (array) $extra );
+		$url  = add_query_arg( $args, admin_url( 'admin-post.php' ) );
+
+		return add_query_arg( '_wpnonce', wp_create_nonce( 'bsr_view_details' ), $url );
 	}
 
 	/**
@@ -218,49 +283,83 @@ class BSR_Admin {
 	 * @access public
 	 */
 	public function load_details() {
-
-		if ( get_transient( 'bsr_results' ) ) {
-			$results 		= get_transient( 'bsr_results' );
-			$min 			= ( defined( 'SCRIPT_DEBUG' ) && true === SCRIPT_DEBUG ) ? '' : '.min';
-			$bsr_styles 	= BSR_URL . 'assets/css/better-search-replace.css?v=' . BSR_VERSION;
-
-			?>
-			<link href="<?php echo esc_url( get_admin_url( null, '/css/common' . $min . '.css' ) ); ?>" rel="stylesheet" type="text/css" />
-			<link href="<?php echo esc_url( $bsr_styles ); ?>" rel="stylesheet" type="text/css">
-
-			<div style="padding: 32px; background-color: var(--color-white); min-height: 100%;">
-				<table id="bsr-results-table" class="widefat">
-					<thead>
-						<tr><th class="bsr-first"><?php _e( 'Table', 'better-search-replace' ); ?></th><th class="bsr-second"><?php _e( 'Changes Found', 'better-search-replace' ); ?></th><th class="bsr-third"><?php _e( 'Rows Updated', 'better-search-replace' ); ?></th><th class="bsr-fourth"><?php _e( 'Time', 'better-search-replace' ); ?></th></tr>
-					</thead>
-					<tbody>
-					<?php
-						foreach ( $results['table_reports'] as $table_name => $report ) {
-							$time = $report['end'] - $report['start'];
-
-							if ( $report['change'] != 0 ) {
-								$report['change'] = '<a class="tooltip">' . esc_html( $report['change'] ). '</a>';
-
-								$upgrade_link = sprintf(
-									__( '<a href="%s" target="_blank">UPGRADE</a> to view details on the exact changes that will be made.', 'better-search-replace'),
-									'https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=tooltip&utm_campaign=bsr-to-migrate'
-								);
-
-								$report['change'] .= '<span class="helper-message right">' . $upgrade_link . '</span>';
-							}
-
-							if ( $report['updates'] != 0 ) {
-								$report['updates'] = '<strong>' . esc_html( $report['updates'] ) . '</strong>';
-							}
-
-							echo '<tr><td class="bsr-first">' . esc_html( $table_name ) . '</td><td class="bsr-second">' . $report['change'] . '</td><td class="bsr-third">' . $report['updates'] . '</td><td class="bsr-fourth">' . round( $time, 3 ) . __( ' seconds', 'better-search-replace' ) . '</td></tr>';
-						}
-					?>
-					</tbody>
-				</table>
-			</div>
-			<?php
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Nonce verified below; Thickbox GET must not rely on referer.
+		if ( ! isset( $_REQUEST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( (string) $_REQUEST['_wpnonce'] ) ), 'bsr_view_details' ) ) {
+			wp_die( esc_html__( 'Security check failed.', 'better-search-replace' ), '', array( 'response' => 403 ) );
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
+
+		if ( ! bsr_enabled_for_user() ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to view this content.', 'better-search-replace' ), '', array( 'response' => 403 ) );
+		}
+
+		if ( ! get_transient( 'bsr_results' ) ) {
+			return;
+		}
+
+		$results = get_transient( 'bsr_results' );
+		$min     = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		wp_enqueue_style( 'common' );
+		wp_enqueue_style(
+			'better-search-replace',
+			BSR_URL . 'assets/css/better-search-replace' . $min . '.css',
+			array( 'common' ),
+			BSR_VERSION,
+			'all'
+		);
+		wp_print_styles( array( 'common', 'better-search-replace' ) );
+
+		$upgrade_url = 'https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=tooltip&utm_campaign=bsr-to-migrate';
+		?>
+		<div style="padding: 32px; background-color: var(--color-white); min-height: 100%;">
+			<table id="bsr-results-table" class="widefat">
+				<thead>
+					<tr>
+						<th class="bsr-first"><?php esc_html_e( 'Table', 'better-search-replace' ); ?></th>
+						<th class="bsr-second"><?php esc_html_e( 'Changes Found', 'better-search-replace' ); ?></th>
+						<th class="bsr-third"><?php esc_html_e( 'Rows Updated', 'better-search-replace' ); ?></th>
+						<th class="bsr-fourth"><?php esc_html_e( 'Time', 'better-search-replace' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+				<?php
+				foreach ( $results['table_reports'] as $table_name => $report ) {
+					$time = $report['end'] - $report['start'];
+
+					$change_cell = '';
+					if ( 0 !== (int) $report['change'] ) {
+						$change_cell  = '<a class="tooltip">' . esc_html( (string) $report['change'] ) . '</a>';
+						$change_cell .= '<span class="helper-message right">';
+						$change_cell .= wp_kses_post(
+							sprintf(
+								/* translators: %s: URL to the upgrade page. */
+								__( '<a href="%s" target="_blank">UPGRADE</a> to view details on the exact changes that will be made.', 'better-search-replace' ),
+								esc_url( $upgrade_url )
+							)
+						);
+						$change_cell .= '</span>';
+					}
+
+					$updates_cell = '0';
+					if ( 0 !== (int) $report['updates'] ) {
+						$updates_cell = '<strong>' . esc_html( (string) $report['updates'] ) . '</strong>';
+					}
+
+					printf(
+						'<tr><td class="bsr-first">%1$s</td><td class="bsr-second">%2$s</td><td class="bsr-third">%3$s</td><td class="bsr-fourth">%4$s%5$s</td></tr>',
+						esc_html( $table_name ),
+						wp_kses_post( $change_cell ),
+						wp_kses_post( $updates_cell ),
+						esc_html( (string) round( $time, 3 ) ),
+						esc_html__( ' seconds', 'better-search-replace' )
+					);
+				}
+				?>
+				</tbody>
+			</table>
+		</div>
+		<?php
 	}
 
 	/**
@@ -276,7 +375,13 @@ class BSR_Admin {
 	 * @access public
 	 */
 	public function download_sysinfo() {
-		if ( ! BSR_Utils::check_admin_referer( 'bsr_download_sysinfo', 'bsr_sysinfo_nonce' ) ) {
+		if ( ! BSR_Utils::check_admin_referer( 'bsr_download_sysinfo', 'bsr_sysinfo_nonce', false ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Nonce verified via BSR_Utils::check_admin_referer() above; PHPCS does not recognize the wrapper.
+		if ( ! isset( $_POST['bsr-sysinfo'] ) ) {
+			// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
@@ -285,7 +390,11 @@ class BSR_Admin {
 		header( 'Content-Type: text/plain' );
 		header( 'Content-Disposition: attachment; filename="bsr-system-info.txt"' );
 
-		echo wp_strip_all_tags( $_POST['bsr-sysinfo'] );
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verified via BSR_Utils::check_admin_referer(); isset() above; plain-text system info for download; tags stripped below.
+		$sysinfo = wp_unslash( (string) $_POST['bsr-sysinfo'] );
+
+		echo esc_html( wp_strip_all_tags( $sysinfo ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 		die();
 	}
 
@@ -300,7 +409,9 @@ class BSR_Admin {
 		if ( $file == $plugin ) {
 			return array_merge(
 				$links,
-				array( '<a href="https://bettersearchreplace.com/?utm_source=insideplugin&utm_medium=web&utm_content=plugins-page&utm_campaign=pro-upsell">' . __( 'Upgrade to Pro', 'better-search-replace' ) . '</a>' )
+				array(
+					'<a href="' . esc_url( 'https://bettersearchreplace.com/?utm_source=insideplugin&utm_medium=web&utm_content=plugins-page&utm_campaign=pro-upsell' ) . '">' . esc_html__( 'Upgrade to Pro', 'better-search-replace' ) . '</a>',
+				)
 			);
 		}
 

--- a/includes/class-bsr-ajax.php
+++ b/includes/class-bsr-ajax.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * AJAX-specific functionality for the plugin.
  *
@@ -14,6 +18,13 @@
 if ( ! defined( 'BSR_PATH' ) ) exit;
 
 class BSR_AJAX {
+
+	/**
+	 * Sanitized `bsr-ajax` action when `is_authenticated_bsr_ajax_request()` passes.
+	 *
+	 * @var string
+	 */
+	private $authenticated_ajax_action = '';
 
 	/**
 	 * Initiate our custom ajax handlers.
@@ -31,7 +42,42 @@ class BSR_AJAX {
 	 * @return string
 	 */
 	public static function get_endpoint() {
-		return esc_url_raw( get_admin_url() . 'tools.php?page=better-search-replace&bsr-ajax=' );
+		return esc_url_raw(
+			add_query_arg(
+				'page',
+				'better-search-replace',
+				admin_url( 'tools.php' )
+			)
+		);
+	}
+
+	/**
+	 * Custom admin AJAX requests must include a valid nonce and capability.
+	 *
+	 * @return bool
+	 */
+	private function is_authenticated_bsr_ajax_request() {
+		$this->authenticated_ajax_action = '';
+
+		if ( ! isset( $_REQUEST['bsr_ajax_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( (string) $_REQUEST['bsr_ajax_nonce'] ) ), 'bsr_ajax_nonce' ) ) {
+			return false;
+		}
+		if ( ! isset( $_REQUEST['bsr-ajax'] ) ) {
+			return false;
+		}
+
+		$ajax_action = sanitize_text_field( wp_unslash( (string) $_REQUEST['bsr-ajax'] ) );
+		if ( empty( $ajax_action ) ) {
+			return false;
+		}
+
+		if ( ! bsr_enabled_for_user() ) {
+			return false;
+		}
+
+		$this->authenticated_ajax_action = $ajax_action;
+
+		return true;
 	}
 
 	/**
@@ -40,27 +86,24 @@ class BSR_AJAX {
 	 */
 	public function define_ajax() {
 
-		if ( isset( $_GET['bsr-ajax'] ) && ! empty( $_GET['bsr-ajax'] ) ) {
-
-			// Define the WordPress "DOING_AJAX" constant.
-			if ( ! defined( 'DOING_AJAX' ) ) {
-				define( 'DOING_AJAX', true );
-			}
-
-			// Prevent notices from breaking AJAX functionality.
-			if ( ! WP_DEBUG || ( WP_DEBUG && ! WP_DEBUG_DISPLAY ) ) {
-				@ini_set( 'display_errors', 0 );
-			}
-
-			// Send the headers.
-			send_origin_headers();
-			@header( 'Content-Type: text/html; charset=' . get_option( 'blog_charset' ) );
-			@header( 'X-Robots-Tag: noindex' );
-			send_nosniff_header();
-			nocache_headers();
-
+		if ( ! $this->is_authenticated_bsr_ajax_request() ) {
+			return;
 		}
 
+		if ( ! defined( 'DOING_AJAX' ) ) {
+			define( 'DOING_AJAX', true );
+		}
+
+		if ( ! WP_DEBUG || ( WP_DEBUG && ! WP_DEBUG_DISPLAY ) ) {
+			// phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged
+			@ini_set( 'display_errors', 0 );
+		}
+
+		send_origin_headers();
+		@header( 'Content-Type: text/html; charset=' . get_option( 'blog_charset' ) );
+		@header( 'X-Robots-Tag: noindex' );
+		send_nosniff_header();
+		nocache_headers();
 	}
 
 	/**
@@ -70,11 +113,14 @@ class BSR_AJAX {
 	public function do_bsr_ajax() {
 		global $wp_query;
 
-		if ( isset( $_GET['bsr-ajax'] ) && ! empty( $_GET['bsr-ajax'] ) ) {
-			$wp_query->set( 'bsr-ajax', sanitize_text_field( $_GET['bsr-ajax'] ) );
+		if ( ! $this->is_authenticated_bsr_ajax_request() ) {
+			return;
 		}
 
+		$wp_query->set( 'bsr-ajax', $this->authenticated_ajax_action );
+
 		if ( $action = $wp_query->get( 'bsr-ajax' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Dynamic bsr_ajax_{$action} hooks; literal prefix bsr_ajax_.
 			do_action( 'bsr_ajax_' . sanitize_text_field( $action ) );
 			die();
 		}
@@ -90,6 +136,7 @@ class BSR_AJAX {
 		);
 
 		foreach ( $actions as $action ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Action name built from allowlisted values; prefix bsr_ajax_.
 			add_action( 'bsr_ajax_' . $action, array( $this, $action ) );
 		}
 	}
@@ -99,22 +146,22 @@ class BSR_AJAX {
 	 * @access public
 	 */
 	public function process_search_replace() {
-		// Bail if not authorized.
-		if ( ! BSR_Utils::check_admin_referer( 'bsr_ajax_nonce', 'bsr_ajax_nonce' ) ) {
+		if ( ! BSR_Utils::check_admin_referer( 'bsr_ajax_nonce', 'bsr_ajax_nonce', false ) ) {
 			return;
 		}
 
-		// Initialize the DB class.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Nonce and capability verified via BSR_Utils::check_admin_referer(); PHPCS does not recognize the wrapper.
+
 		$db   = new BSR_DB();
-		$step = isset( $_REQUEST['bsr_step' ] ) ? absint( $_REQUEST['bsr_step'] ) : 0;
+		$step = isset( $_REQUEST['bsr_step'] ) ? absint( $_REQUEST['bsr_step'] ) : 0;
 		$page = isset( $_REQUEST['bsr_page'] ) ? absint( $_REQUEST['bsr_page'] ) : 0;
 
-		// Any operations that should only be performed at the beginning.
-		if ( $step === 0 && $page === 0 ) {
+		if ( 0 === $step && 0 === $page ) {
 			$args = array();
-			parse_str( $_POST['bsr_data'], $args );
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotValidated -- bsr_data is URL-encoded form body; parsed after nonce; fields validated when applied.
+			$bsr_data_raw = isset( $_REQUEST['bsr_data'] ) ? wp_unslash( (string) $_REQUEST['bsr_data'] ) : '';
+			parse_str( $bsr_data_raw, $args );
 
-			// Build the arguments for this run.
 			if ( ! isset( $args['select_tables'] ) || ! is_array( $args['select_tables'] ) ) {
 				$args['select_tables'] = array();
 			}
@@ -131,66 +178,68 @@ class BSR_AJAX {
 
 			$args['total_pages'] = isset( $args['total_pages'] ) ? absint( $args['total_pages'] ) : $db->get_total_pages( $args['select_tables'] );
 
-			// Clear the results of the last run.
 			delete_transient( 'bsr_results' );
 			delete_option( 'bsr_data' );
 		} else {
 			$args = get_option( 'bsr_data' );
+			if ( ! is_array( $args ) ) {
+				$args = array(
+					'select_tables'   => array(),
+					'total_pages'     => 1,
+					'completed_pages' => 0,
+				);
+			}
 		}
 
-		// Start processing data.
-		if ( isset( $args['select_tables'][$step] ) ) {
+		if ( isset( $args['select_tables'][ $step ] ) ) {
 
-			$result = $db->srdb( $args['select_tables'][$step], $page, $args );
-			$this->append_report( $args['select_tables'][$step], $result['table_report'], $args );
+			$result = $db->srdb( $args['select_tables'][ $step ], $page, $args );
+			$this->append_report( $args['select_tables'][ $step ], $result['table_report'], $args );
 
 			if ( false === $result['table_complete'] ) {
-				$page++;
+				++$page;
 			} else {
-				$step++;
+				++$step;
 				$page = 0;
 			}
 
-			// Check if isset() again as the step may have changed since last check.
-			if ( isset( $args['select_tables'][$step] ) ) {
-				$msg_tbl = esc_html( $args['select_tables'][$step] );
+			if ( isset( $args['select_tables'][ $step ] ) ) {
+				$msg_tbl = esc_html( $args['select_tables'][ $step ] );
 
 				$message = sprintf(
-					__( 'Processing table %d of %d: %s', 'better-search-replace' ),
+					/* translators: 1: current table number, 2: total number of tables, 3: table name. */
+					__( 'Processing table %1$d of %2$d: %3$s', 'better-search-replace' ),
 					$step + 1,
 					count( $args['select_tables'] ),
 					$msg_tbl
 				);
 			}
 
-			$args['completed_pages']++;
+			++$args['completed_pages'];
 			$percentage = $args['completed_pages'] / $args['total_pages'] * 100 . '%';
 
 		} else {
 			$db->maybe_update_site_url();
-			$step 		= 'done';
+			$step       = 'done';
 			$percentage = '100%';
 		}
 
 		update_option( 'bsr_data', $args );
 
-		// Store results in an array.
 		$result = array(
-			'step' 				=> $step,
-			'page' 				=> $page,
-			'percentage'		=> $percentage,
-			'url' 				=> get_admin_url() . 'tools.php?page=better-search-replace&tab=bsr_search_replace&result=true',
-			'bsr_data' 			=> build_query( $args )
+			'step'         => $step,
+			'page'         => $page,
+			'percentage'   => $percentage,
+			'url'          => esc_url_raw( BSR_Utils::tools_page_url( array( 'tab' => 'bsr_search_replace', 'result' => 'true' ) ) ),
+			'bsr_data'     => build_query( $args ),
 		);
 
 		if ( isset( $message ) ) {
 			$result['message'] = $message;
 		}
 
-		// Send output as JSON for processing via AJAX.
-		echo json_encode( $result );
-		exit;
-
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
+		wp_send_json( $result );
 	}
 
 	/**
@@ -203,47 +252,39 @@ class BSR_AJAX {
 	 */
 	public function append_report( $table, $report, $args ) {
 
-		// Bail if not authorized.
-		if ( ! BSR_Utils::check_admin_referer( 'bsr_ajax_nonce', 'bsr_ajax_nonce' ) ) {
+		if ( ! BSR_Utils::check_admin_referer( 'bsr_ajax_nonce', 'bsr_ajax_nonce', false ) ) {
 			return false;
 		}
 
-		// Retrieve the existing transient.
-		$results = get_transient( 'bsr_results' ) ? get_transient( 'bsr_results') : array();
+		$results = get_transient( 'bsr_results' ) ? get_transient( 'bsr_results' ) : array();
 
-		// Grab any values from the run args.
-		$results['search_for'] 			= isset( $args['search_for'] ) ? $args['search_for'] : '';
-		$results['replace_with'] 		= isset( $args['replace_with'] ) ? $args['replace_with'] : '';
-		$results['dry_run'] 			= isset( $args['dry_run'] ) ? $args['dry_run'] : 'off';
-		$results['case_insensitive'] 	= isset( $args['case_insensitive'] ) ? $args['case_insensitive'] : 'off';
-		$results['replace_guids'] 		= isset( $args['replace_guids'] ) ? $args['replace_guids'] : 'off';
+		$results['search_for']       = isset( $args['search_for'] ) ? $args['search_for'] : '';
+		$results['replace_with']    = isset( $args['replace_with'] ) ? $args['replace_with'] : '';
+		$results['dry_run']         = isset( $args['dry_run'] ) ? $args['dry_run'] : 'off';
+		$results['case_insensitive'] = isset( $args['case_insensitive'] ) ? $args['case_insensitive'] : 'off';
+		$results['replace_guids']   = isset( $args['replace_guids'] ) ? $args['replace_guids'] : 'off';
 
-		// Sum the values of the new and existing reports.
-		$results['change'] 	= isset( $results['change'] ) ? $results['change'] + $report['change'] : $report['change'];
+		$results['change']  = isset( $results['change'] ) ? $results['change'] + $report['change'] : $report['change'];
 		$results['updates'] = isset( $results['updates'] ) ? $results['updates'] + $report['updates'] : $report['updates'];
 
-		// Append the table report, or create a new one if necessary.
-		if ( isset( $results['table_reports'] ) && isset( $results['table_reports'][$table] ) ) {
-			$results['table_reports'][$table]['change'] 	= $results['table_reports'][$table]['change'] + $report['change'];
-			$results['table_reports'][$table]['updates'] 	= $results['table_reports'][$table]['updates'] + $report['updates'];
-			$results['table_reports'][$table]['end'] 		= $report['end'];
+		if ( isset( $results['table_reports'] ) && isset( $results['table_reports'][ $table ] ) ) {
+			$results['table_reports'][ $table ]['change']  = $results['table_reports'][ $table ]['change'] + $report['change'];
+			$results['table_reports'][ $table ]['updates'] = $results['table_reports'][ $table ]['updates'] + $report['updates'];
+			$results['table_reports'][ $table ]['end']     = $report['end'];
 		} else {
-			$results['table_reports'][$table] = $report;
+			$results['table_reports'][ $table ] = $report;
 		}
 
-		// Count the number of tables.
 		$results['tables'] = count( $results['table_reports'] );
 
-		// Update the transient.
 		if ( ! set_transient( 'bsr_results', $results, DAY_IN_SECONDS ) ) {
 			return false;
 		}
 
 		return true;
-
 	}
-
 }
-
-$bsr_ajax = new BSR_AJAX;
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+$bsr_ajax = new BSR_AJAX();
 $bsr_ajax->init();
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound

--- a/includes/class-bsr-compatibility.php
+++ b/includes/class-bsr-compatibility.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Processes compatibility functionality.
  * @since      1.0
@@ -48,7 +52,7 @@ class BSR_Compatibility {
 		$return .= 'PHP Version:              ' . PHP_VERSION . "\n";
 		$return .= 'MySQL Version:            ' . $wpdb->db_version() . "\n";
 
-		$return .= 'Server Software:          ' . $_SERVER['SERVER_SOFTWARE'] . "\n";
+		$return .= 'Server Software:          ' . self::get_server_software_for_display() . "\n";
 
 		// PHP configs... now we're getting to the important stuff
 		$return .= "\n" . '-- PHP Configuration' . "\n\n";
@@ -93,6 +97,19 @@ class BSR_Compatibility {
 
 		$return .= "\n" . '### End System Info ###';
 		return $return;
+	}
+
+	/**
+	 * Server software string for system info (safe for display in plain-text export).
+	 *
+	 * @return string
+	 */
+	private static function get_server_software_for_display() {
+		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) ) {
+			return '';
+		}
+
+		return sanitize_text_field( wp_unslash( (string) $_SERVER['SERVER_SOFTWARE'] ) );
 	}
 
 	/**

--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Processes database-related functionality.
  * @since      1.0
@@ -7,6 +6,10 @@
  * @package    Better_Search_Replace
  * @subpackage Better_Search_Replace/includes
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 // Prevent direct access.
 if ( ! defined( 'BSR_PATH' ) ) exit;
@@ -51,18 +54,19 @@ class BSR_DB {
 	public static function get_tables() {
 		global $wpdb;
 
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema discovery; not suitable for long-lived object cache.
 		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
 
 			if ( is_main_site() ) {
-				$tables 	= $wpdb->get_col( 'SHOW TABLES' );
+				$tables = $wpdb->get_col( 'SHOW TABLES' );
 			} else {
-				$blog_id 	= get_current_blog_id();
-				$tables 	= $wpdb->get_col( "SHOW TABLES LIKE '" . $wpdb->base_prefix . absint( $blog_id ) . "\_%'" );
+				$blog_id = get_current_blog_id();
+				$tables  = $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->base_prefix . absint( $blog_id ) . '\_%' ) );
 			}
-
 		} else {
 			$tables = $wpdb->get_col( 'SHOW TABLES' );
 		}
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		return $tables;
 	}
@@ -75,16 +79,21 @@ class BSR_DB {
 	public static function get_sizes() {
 		global $wpdb;
 
-		$sizes 	= array();
-		$tables	= $wpdb->get_results( 'SHOW TABLE STATUS', ARRAY_A );
+		$sizes = array();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Server metadata for admin display only.
+		$tables = $wpdb->get_results( 'SHOW TABLE STATUS', ARRAY_A );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		if ( is_array( $tables ) && ! empty( $tables ) ) {
 
 			foreach ( $tables as $table ) {
 				$size = round( $table['Data_length'] / 1024 / 1024, 2 );
-				$sizes[$table['Name']] = sprintf( __( '(%s MB)', 'better-search-replace' ), $size );
+				$sizes[ $table['Name'] ] = sprintf(
+					/* translators: %s: table size in megabytes. */
+					__( '(%s MB)', 'better-search-replace' ),
+					$size
+				);
 			}
-
 		}
 
 		return $sizes;
@@ -110,9 +119,12 @@ class BSR_DB {
 			return 0;
 		}
 
-		$table 	= esc_sql( $table );
-		$rows 	= $this->wpdb->get_var( "SELECT COUNT(*) FROM `$table`" );
-		$pages 	= ceil( $rows / $this->page_size );
+		$wpdb = $this->wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Row count on allowlisted table name; not suitable for object cache.
+		$rows = $wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $table ) );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$pages = ceil( $rows / $this->page_size );
 
 		return absint( $pages );
 	}
@@ -155,7 +167,10 @@ class BSR_DB {
 			return array( $primary_key, $columns );
 		}
 
-		$fields  		= $this->wpdb->get_results( 'DESCRIBE ' . $table );
+		$wpdb = $this->wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter -- DESCRIBE on allowlisted table for SRDB column list.
+		$fields = $wpdb->get_results( $wpdb->prepare( 'DESCRIBE %i', $table ) );
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter
 
 		if ( is_array( $fields ) ) {
 			foreach ( $fields as $column ) {
@@ -185,53 +200,71 @@ class BSR_DB {
 	 */
 	public function srdb( $table, $page, $args ) {
 
-		// Load up the default settings for this chunk.
-		$table 			= esc_sql( $table );
-		$current_page 	= absint( $page );
-		$pages 			= $this->get_pages_in_table( $table );
-		$done 			= false;
+		if ( ! $this->table_exists( $table ) ) {
+			$table_report = array(
+				'change'    => 0,
+				'updates'   => 0,
+				'start'     => microtime( true ),
+				'end'       => microtime( true ),
+				'errors'    => array(),
+				'skipped'   => true,
+			);
+			return array( 'table_complete' => true, 'table_report' => $table_report );
+		}
 
-		$args['search_for'] 	= str_replace( '#BSR_BACKSLASH#', '\\', $args['search_for'] );
-		$args['replace_with'] 	= str_replace( '#BSR_BACKSLASH#', '\\', $args['replace_with'] );
+		$wpdb = $this->wpdb;
+
+		$current_page = absint( $page );
+		$pages        = $this->get_pages_in_table( $table );
+		$done         = false;
+
+		$args['search_for']   = str_replace( '#BSR_BACKSLASH#', '\\', $args['search_for'] );
+		$args['replace_with'] = str_replace( '#BSR_BACKSLASH#', '\\', $args['replace_with'] );
 
 		$table_report = array(
-			'change' 	=> 0,
-			'updates' 	=> 0,
-			'start' 	=> microtime( true ),
-			'end'		=> microtime( true ),
-			'errors' 	=> array(),
-			'skipped' 	=> false
+			'change'   => 0,
+			'updates'  => 0,
+			'start'    => microtime( true ),
+			'end'      => microtime( true ),
+			'errors'   => array(),
+			'skipped'  => false,
 		);
 
-		// Get a list of columns in this table.
 		list( $primary_key, $columns ) = $this->get_columns( $table );
 
-		// Bail out early if there isn't a primary key.
 		if ( null === $primary_key ) {
 			$table_report['skipped'] = true;
 			return array( 'table_complete' => true, 'table_report' => $table_report );
 		}
 
-		$current_row 	= 0;
-		$start 			= $page * $this->page_size;
-		$end 			= $this->page_size;
+		$current_row = 0;
+		$start       = $page * $this->page_size;
+		$end         = $this->page_size;
 
-		// Grab the content of the table.
-		$data = $this->wpdb->get_results( "SELECT * FROM `$table` LIMIT $start, $end", ARRAY_A );
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter -- Paged read of allowlisted table for batch search/replace.
+		$data = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i LIMIT %d, %d',
+				$table,
+				$start,
+				$end
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter
 
-		// Loop through the data.
 		foreach ( $data as $row ) {
 			$current_row++;
 			$update_sql = array();
-			$where_sql 	= array();
-			$upd 		= false;
+			$where_sql  = array();
+			$upd        = false;
 
-			foreach( $columns as $column ) {
+			foreach ( $columns as $column ) {
 
 				$data_to_fix = $row[ $column ];
 
 				if ( $column == $primary_key ) {
-					$where_sql[] = $column . ' = "' .  $this->mysql_escape_mimic( $data_to_fix ) . '"';
+					$where_sql[] = $column . ' = "' . $this->mysql_escape_mimic( $data_to_fix ) . '"';
 					continue;
 				}
 
@@ -240,7 +273,7 @@ class BSR_DB {
 					continue;
 				}
 
-				if ( $this->wpdb->options === $table ) {
+				if ( $wpdb->options === $table ) {
 
 					// Skip any BSR options as they may contain the search field.
 					if ( isset( $should_skip ) && true === $should_skip ) {
@@ -250,8 +283,8 @@ class BSR_DB {
 
 					// If the Site URL needs to be updated, let's do that last.
 					if ( isset( $update_later ) && true === $update_later ) {
-						$update_later 	= false;
-						$edited_data 	= $this->recursive_unserialize_replace( $args['search_for'], $args['replace_with'], $data_to_fix, false, $args['case_insensitive'] );
+						$update_later = false;
+						$edited_data  = $this->recursive_unserialize_replace( $args['search_for'], $args['replace_with'], $data_to_fix, false, $args['case_insensitive'] );
 
 						if ( $edited_data != $data_to_fix ) {
 							$table_report['change']++;
@@ -268,7 +301,6 @@ class BSR_DB {
 					if ( 'siteurl' === $data_to_fix && $args['dry_run'] !== 'on' ) {
 						$update_later = true;
 					}
-
 				}
 
 				// Run a search replace on the data that'll respect the serialisation.
@@ -277,10 +309,9 @@ class BSR_DB {
 				// Something was changed
 				if ( $edited_data != $data_to_fix ) {
 					$update_sql[] = $column . ' = "' . $this->mysql_escape_mimic( $edited_data ) . '"';
-					$upd = true;
+					$upd          = true;
 					$table_report['change']++;
 				}
-
 			}
 
 			// Determine what to do with updates.
@@ -288,26 +319,32 @@ class BSR_DB {
 				// Don't do anything if a dry run
 			} elseif ( $upd && ! empty( $where_sql ) ) {
 				// If there are changes to make, run the query.
-				$sql 	= 'UPDATE ' . $table . ' SET ' . implode( ', ', $update_sql ) . ' WHERE ' . implode( ' AND ', array_filter( $where_sql ) );
-				$result = $this->wpdb->query( $sql );
+				$t   = esc_sql( $table );
+				$sql = 'UPDATE `' . $t . '` SET ' . implode( ', ', $update_sql ) . ' WHERE ' . implode( ' AND ', array_filter( $where_sql ) );
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Dynamic UPDATE: table allowlisted; columns from DESCRIBE; values escaped via mysql_escape_mimic().
+				$result = $wpdb->query( $sql );
+				// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
 
 				if ( ! $result ) {
-					$table_report['errors'][] = sprintf( __( 'Error updating row: %d.', 'better-search-replace' ), $current_row );
+					$table_report['errors'][] = sprintf(
+						/* translators: %d: database row number that failed to update. */
+						__( 'Error updating row: %d.', 'better-search-replace' ),
+						$current_row
+					);
 				} else {
 					$table_report['updates']++;
 				}
-
 			}
-
 		} // end row loop
 
 		if ( $current_page >= $pages - 1 ) {
 			$done = true;
 		}
 
-		// Flush the results and return the report.
 		$table_report['end'] = microtime( true );
-		$this->wpdb->flush();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Clear wpdb result buffers after batch SRDB.
+		$wpdb->flush();
+
 		return array( 'table_complete' => $done, 'table_report' => $table_report );
 	}
 
@@ -490,7 +527,7 @@ class BSR_DB {
 	 * @return bool
 	 */
 	private function table_exists( $table ) {
-		return in_array( $table, $this->get_tables() );
+		return in_array( $table, self::get_tables(), true );
 	}
 
 	/**

--- a/includes/class-bsr-i18n.php
+++ b/includes/class-bsr-i18n.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Define the internationalization functionality.
  *
@@ -14,6 +18,7 @@
 // Prevent direct access.
 if ( ! defined( 'BSR_PATH' ) ) exit;
 
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Historical class name; loaded by BSR_Loader.
 class BSR_i18n {
 
 	/**

--- a/includes/class-bsr-loader.php
+++ b/includes/class-bsr-loader.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Register all actions and filters for the plugin
  *

--- a/includes/class-bsr-main.php
+++ b/includes/class-bsr-main.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * The core plugin class.
  *

--- a/includes/class-bsr-plugin-footer.php
+++ b/includes/class-bsr-plugin-footer.php
@@ -1,4 +1,9 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
 * Plugin footer functionality for the plugin
 *

--- a/includes/class-bsr-templates-helper.php
+++ b/includes/class-bsr-templates-helper.php
@@ -1,8 +1,13 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Prevent direct access.
 if ( ! defined( 'BSR_PATH' ) ) exit;
 
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Historical class name; used by admin templates.
 class BSR_Templates_Helper {
     /**
      * Returns a fully qualified path for the given active tab name

--- a/includes/class-bsr-utils.php
+++ b/includes/class-bsr-utils.php
@@ -1,4 +1,9 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Utility functionality for the plugin
  *
@@ -16,6 +21,9 @@ if ( ! defined( 'BSR_PATH' ) ) {
 class BSR_Utils {
 	const BSR_URL = 'https://bettersearchreplace.com';
 	const WPE_URL = 'https://wpengine.com';
+
+	/** Nonce action for tools.php?page=better-search-replace screen query args (redirects, tab links). */
+	const TOOLS_SCREEN_NONCE_ACTION = 'bsr_tools_screen';
 
 	/**
 	 * Create an external link for given URL.
@@ -91,6 +99,46 @@ class BSR_Utils {
 	}
 
 	/**
+	 * Tools → Better Search Replace URL with a nonce for GET query args on that screen.
+	 *
+	 * @param array $args Query arguments (merged with page=better-search-replace).
+	 * @return string Unescaped URL; pass through esc_url() for HTML or esc_url_raw() for redirects.
+	 */
+	public static function tools_page_url( $args = array() ) {
+		$url = add_query_arg(
+			array_merge(
+				array( 'page' => 'better-search-replace' ),
+				$args
+			),
+			admin_url( 'tools.php' )
+		);
+
+		return add_query_arg( '_wpnonce', wp_create_nonce( self::TOOLS_SCREEN_NONCE_ACTION ), $url );
+	}
+
+	/**
+	 * Whether the current tools screen GET request may use BSR-specific query args (result, import, profile, etc.).
+	 * Missing nonce is allowed for backward compatibility when the user is already authorized.
+	 *
+	 * @return bool
+	 */
+	public static function validate_tools_screen_get() {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Nonce is verified below when present; capability is always required.
+		if ( ! bsr_enabled_for_user() ) {
+			return false;
+		}
+		if ( ! isset( $_GET['_wpnonce'] ) ) {
+			// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		$valid = (bool) wp_verify_nonce( sanitize_text_field( wp_unslash( (string) $_GET['_wpnonce'] ) ), self::TOOLS_SCREEN_NONCE_ACTION );
+		// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
+
+		return $valid;
+	}
+
+	/**
 	 * Is current admin screen for bsr.
 	 *
 	 * @return bool
@@ -108,10 +156,11 @@ class BSR_Utils {
 	 *
 	 * @param int|string $action    The nonce action.
 	 * @param string     $query_arg Key to check for nonce in `$_REQUEST`.
+	 * @param bool       $die       Whether to die on failure (default false so callers can return JSON/redirects).
 	 *
 	 * @return bool
 	 */
-	public static function check_admin_referer( $action, $query_arg ) {
-		return check_admin_referer( $action, $query_arg ) && bsr_enabled_for_user();
+	public static function check_admin_referer( $action, $query_arg, $die = false ) {
+		return check_admin_referer( $action, $query_arg, $die ) && bsr_enabled_for_user();
 	}
 }

--- a/templates/bsr-dashboard.php
+++ b/templates/bsr-dashboard.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Displays the main Better Search Replace page under Tools -> Better Search Replace.
  *
@@ -13,19 +17,25 @@
 // Prevent direct access.
 if ( ! defined( 'BSR_PATH' ) ) exit;
 
-// Determines which tab to display.
-$active_tab = isset( $_GET['tab'] ) ? $_GET['tab'] : 'bsr_search_replace';
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template partial loaded in BSR admin context; variables are file scope, not WordPress globals.
 
-switch( $active_tab ) {
-	case 'bsr_settings':
-		$action = 'action="' . get_admin_url() . 'options.php' . '"';
-		break;
-	case 'bsr_help':
-		$action = 'action="' . get_admin_url() . 'admin-post.php' . '"';
-		break;
-	default:
-		$action = '';
+// phpcs:disable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended -- Tab is sanitized and matched against allowlist; optional tools-screen nonce verified when present.
+$allowed_tabs = array( 'bsr_search_replace', 'bsr_settings', 'bsr_help' );
+$active_tab   = 'bsr_search_replace';
+$tab_candidate  = '';
+if ( isset( $_GET['tab'] ) ) {
+	$tab_candidate = sanitize_key( wp_unslash( (string) $_GET['tab'] ) );
 }
+if ( '' !== $tab_candidate ) {
+	$nonce_ok = true;
+	if ( isset( $_GET['_wpnonce'] ) ) {
+		$nonce_ok = wp_verify_nonce( sanitize_text_field( wp_unslash( (string) $_GET['_wpnonce'] ) ), BSR_Utils::TOOLS_SCREEN_NONCE_ACTION );
+	}
+	if ( $nonce_ok && in_array( $tab_candidate, $allowed_tabs, true ) ) {
+		$active_tab = $tab_candidate;
+	}
+}
+// phpcs:enable WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
 
 if ( 'bsr_settings' === $active_tab ) {
 	$action = get_admin_url() . 'options.php';
@@ -33,24 +43,35 @@ if ( 'bsr_settings' === $active_tab ) {
 	$action = get_admin_url() . 'admin-post.php';
 }
 
+$tab_urls = array(
+	'bsr_search_replace' => BSR_Utils::tools_page_url( array( 'tab' => 'bsr_search_replace' ) ),
+	'bsr_settings'      => BSR_Utils::tools_page_url( array( 'tab' => 'bsr_settings' ) ),
+	'bsr_help'          => BSR_Utils::tools_page_url( array( 'tab' => 'bsr_help' ) ),
+);
+
+$logo_src = plugin_dir_url( __FILE__ ) . '../assets/svg/logo-bsr.svg';
+$icon_src = plugin_dir_url( __FILE__ ) . '../assets/svg/icon-upgrade.svg';
+$upgrade  = 'https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=header&utm_campaign=bsr-to-migrate';
+
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+
 ?>
 
 <div class="wrap" style="display: grid;">
 
-    <div class="bsr-notice-container">
-        <h2 class="hidden"></h2>
-    </div>
+	<div class="bsr-notice-container">
+		<h2 class="hidden"></h2>
+	</div>
 
 	<div class="header">
 
 		<div class="content">
-			<a href="?page=better-search-replace&tab=bsr_search_replace">
-				<img href="?page=better-search-replace&tab=bsr_search_replace" src="<?php echo plugin_dir_url( __FILE__ ) . '../assets/svg/logo-bsr.svg'; ?>" class="logo">
+			<a href="<?php echo esc_url( $tab_urls['bsr_search_replace'] ); ?>">
+				<img src="<?php echo esc_url( $logo_src ); ?>" class="logo" alt="">
 			</a>
-			<a href="https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=header&utm_campaign=bsr-to-migrate
-" target="_blank" class="upgrade-notice">
-				<img src="<?php echo plugin_dir_url( __FILE__ ) . '../assets/svg/icon-upgrade.svg'; ?>">
-				<?php _e( 'Upgrade now and get 50% off', 'better-search-replace' ); ?>
+			<a href="<?php echo esc_url( $upgrade ); ?>" target="_blank" rel="noopener noreferrer" class="upgrade-notice">
+				<img src="<?php echo esc_url( $icon_src ); ?>" alt="">
+				<?php esc_html_e( 'Upgrade now and get 50% off', 'better-search-replace' ); ?>
 			</a>
 		</div>
 
@@ -62,18 +83,19 @@ if ( 'bsr_settings' === $active_tab ) {
 
 	<div class="nav-tab-wrapper">
 		<ul>
-			<li><a href="?page=better-search-replace&tab=bsr_search_replace" class="nav-tab <?php echo $active_tab == 'bsr_search_replace' ? 'nav-tab-active' : ''; ?>"><?php _e( 'Search/Replace', 'better-search-replace' ); ?></a></li>
-			<li><a href="?page=better-search-replace&tab=bsr_settings" class="nav-tab <?php echo $active_tab == 'bsr_settings' ? 'nav-tab-active' : ''; ?>"><?php _e( 'Settings', 'better-search-replace' ); ?></a></li>
-			<li><a href="?page=better-search-replace&tab=bsr_help" class="nav-tab <?php echo $active_tab == 'bsr_help' ? 'nav-tab-active' : ''; ?>"><?php _e( 'Help', 'better-search-replace' ); ?></a></li>
+			<li><a href="<?php echo esc_url( $tab_urls['bsr_search_replace'] ); ?>" class="nav-tab <?php echo esc_attr( 'bsr_search_replace' === $active_tab ? 'nav-tab-active' : '' ); ?>"><?php esc_html_e( 'Search/Replace', 'better-search-replace' ); ?></a></li>
+			<li><a href="<?php echo esc_url( $tab_urls['bsr_settings'] ); ?>" class="nav-tab <?php echo esc_attr( 'bsr_settings' === $active_tab ? 'nav-tab-active' : '' ); ?>"><?php esc_html_e( 'Settings', 'better-search-replace' ); ?></a></li>
+			<li><a href="<?php echo esc_url( $tab_urls['bsr_help'] ); ?>" class="nav-tab <?php echo esc_attr( 'bsr_help' === $active_tab ? 'nav-tab-active' : '' ); ?>"><?php esc_html_e( 'Help', 'better-search-replace' ); ?></a></li>
 		</ul>
 	</div>
 
-	<form class="bsr-action-form" action="<?php echo $action; ?>" method="POST">
+	<form class="bsr-action-form" action="<?php echo esc_url( $action ); ?>" method="POST">
 
 		<?php
-		// Include the correct tab template.
-		$bsr_template = BSR_Templates_Helper::get_tab_template($active_tab);
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template partial; file scope of this include.
+		$bsr_template = BSR_Templates_Helper::get_tab_template( $active_tab );
 		include $bsr_template;
+		// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 		?>
 
 	</form>

--- a/templates/bsr-help.php
+++ b/templates/bsr-help.php
@@ -9,11 +9,18 @@
  * @subpackage Better_Search_Replace/templates
  */
 
-// Prevent direct access.
-if ( ! defined( 'BSR_PATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-$bsr_docs_url    = 'https://bettersearchreplace.com/docs/';
-$bsr_support_url = 'https://wordpress.org/support/plugin/better-search-replace';
+// Prevent direct access.
+if ( ! defined( 'BSR_PATH' ) ) {
+	exit;
+}
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+$bsr_upgrade_url     = 'https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=help-tab&utm_campaign=bsr-to-migrate';
+$bsr_github_url      = 'https://github.com/deliciousbrains/better-search-replace';
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 ?>
 
 <div class="ui-sidebar-wrapper">
@@ -23,7 +30,7 @@ $bsr_support_url = 'https://wordpress.org/support/plugin/better-search-replace';
 		<div class="panel">
 
 			<div class="panel-header">
-				<h3><?php _e( 'Help & Troubleshooting', 'better-search-replace' ); ?></h3>
+				<h3><?php esc_html_e( 'Help & Troubleshooting', 'better-search-replace' ); ?></h3>
 			</div>
 
 			<div class="panel-content">
@@ -31,17 +38,23 @@ $bsr_support_url = 'https://wordpress.org/support/plugin/better-search-replace';
 				<div>
 					<p>
 						<?php
-						printf(
-							__( '<a href="%s" style="font-weight:bold;" target="_blank">Upgrade</a> to gain access to premium features and priority email support.', 'better-search-replace' ),
-							'https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=help-tab&utm_campaign=bsr-to-migrate'
+						echo wp_kses_post(
+							sprintf(
+								/* translators: %s: URL to the upgrade page. */
+								__( '<a href="%s" style="font-weight:bold;" target="_blank" rel="noopener noreferrer">Upgrade</a> to gain access to premium features and priority email support.', 'better-search-replace' ),
+								esc_url( $bsr_upgrade_url )
+							)
 						);
 						?>
 					</p>
 					<p>
 						<?php
-						printf(
-							__( 'Found a bug or have a feature request? Please submit an issue on <a href="%s">GitHub</a>!', 'better-search-replace' ),
-							'https://github.com/deliciousbrains/better-search-replace'
+						echo wp_kses_post(
+							sprintf(
+								/* translators: %s: URL to the GitHub repository. */
+								__( 'Found a bug or have a feature request? Please submit an issue on <a href="%s">GitHub</a>!', 'better-search-replace' ),
+								esc_url( $bsr_github_url )
+							)
 						);
 						?>
 					</p>
@@ -50,17 +63,16 @@ $bsr_support_url = 'https://wordpress.org/support/plugin/better-search-replace';
 				<!--System Info-->
 				<div class="row">
 					<div class="input-text full-width">
-						<label><strong><?php _e( 'System Info', 'better-search-replace' ); ?></strong></label>
-						<textarea readonly="readonly" onclick="this.focus(); this.select()" name='bsr-sysinfo'><?php echo BSR_Compatibility::get_sysinfo(); ?></textarea>
+						<label><strong><?php esc_html_e( 'System Info', 'better-search-replace' ); ?></strong></label>
+						<textarea readonly="readonly" onclick="this.focus(); this.select()" name="bsr-sysinfo"><?php echo esc_textarea( BSR_Compatibility::get_sysinfo() ); ?></textarea>
 					</div>
 				</div>
 
-				<!--Submit Button-->
 				<div class="row">
 					<p class="submit">
 						<input type="hidden" name="action" value="bsr_download_sysinfo" />
 						<?php wp_nonce_field( 'bsr_download_sysinfo', 'bsr_sysinfo_nonce' ); ?>
-						<input type="submit" name="bsr-download-sysinfo" id="bsr-download-sysinfo" class="button button-secondary button-sm" value="Download System Info">
+						<input type="submit" name="bsr-download-sysinfo" id="bsr-download-sysinfo" class="button button-secondary button-sm" value="<?php echo esc_attr__( 'Download System Info', 'better-search-replace' ); ?>">
 					</p>
 				</div>
 

--- a/templates/bsr-search-replace.php
+++ b/templates/bsr-search-replace.php
@@ -9,9 +9,17 @@
  * @subpackage Better_Search_Replace/templates
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Prevent direct/unauthorized access.
 if ( ! defined( 'BSR_PATH' ) ) exit;
 
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+$bsr_assets = plugin_dir_url( __FILE__ ) . '../assets/svg/';
+$bsr_guid_doc = 'https://wordpress.org/documentation/article/changing-the-site-url/#important-guid-note';
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 ?>
 
 <div id="bsr-search-replace-wrap" class="postbox">
@@ -21,21 +29,20 @@ if ( ! defined( 'BSR_PATH' ) ) exit;
 		<div class="inside">
 
 			<div id="bsr-search-replace-form" class="form-table">
-
 			<!--Hidden and to trigger the dry run notice placement-->
-			<h2 class="hidden">Dry Run Notice</h2>
+			<h2 class="hidden"><?php esc_html_e( 'Dry Run Notice', 'better-search-replace' ); ?></h2>
 
 			<!--Search/Replace Panel-->
 			<div class="panel">
 
 				<div class="panel-header">
-					<h3><?php _e( 'Search/Replace', 'better-search-replace' ); ?></h3>
+					<h3><?php esc_html_e( 'Search/Replace', 'better-search-replace' ); ?></h3>
 					<a href="#" class="tooltip">
-						<img src="<?php echo plugin_dir_url( __FILE__ ) . '../assets/svg/icon-help.svg'; ?>">
+						<img src="<?php echo esc_url( $bsr_assets . 'icon-help.svg' ); ?>" alt="">
 					</a>
-	                <span class="helper-message left">
-	                    <?php _e( 'Search and replace text in the database, including serialized arrays and objects. Be sure to back up your database before running this process.', 'better-search-replace' ); ?>
-	                </span>
+					<span class="helper-message left">
+						<?php esc_html_e( 'Search and replace text in the database, including serialized arrays and objects. Be sure to back up your database before running this process.', 'better-search-replace' ); ?>
+					</span>
 				</div>
 
 				<div class="panel-content">
@@ -43,12 +50,12 @@ if ( ! defined( 'BSR_PATH' ) ) exit;
 					<!--Search/Replace Fields-->
 					<div class="row search-replace">
 						<div class="input-text full-width">
-							<label for="search_for"><strong><?php _e( 'Search for', 'better-search-replace' ); ?></strong></label>
+							<label for="search_for"><strong><?php esc_html_e( 'Search for', 'better-search-replace' ); ?></strong></label>
 							<input id="search_for" class="regular-text" type="text" name="search_for" value="<?php BSR_Admin::prefill_value( 'search_for' ); ?>" />
 						</div>
 
 						<div class="input-text full-width">
-							<label for="replace_with"><strong><?php _e( 'Replace with', 'better-search-replace' ); ?></strong></label>
+							<label for="replace_with"><strong><?php esc_html_e( 'Replace with', 'better-search-replace' ); ?></strong></label>
 							<input id="replace_with" class="regular-text" type="text" name="replace_with" value="<?php BSR_Admin::prefill_value( 'replace_with' ); ?>" />
 						</div>
 					</div>
@@ -56,9 +63,9 @@ if ( ! defined( 'BSR_PATH' ) ) exit;
 					<!--Tables-->
 					<div class="row">
 						<div class="col full-width tables">
-							<label for="select_tables"><strong><?php _e( 'Select tables', 'better-search-replace' ); ?></strong></label>
+							<label for="select_tables"><strong><?php esc_html_e( 'Select tables', 'better-search-replace' ); ?></strong></label>
 								<?php BSR_Admin::load_tables(); ?>
-								<p class="description"><?php _e( 'Select multiple tables with Ctrl-Click for Windows or Cmd-Click for Mac.', 'better-search-replace' ); ?></p>
+								<p class="description"><?php esc_html_e( 'Select multiple tables with Ctrl-Click for Windows or Cmd-Click for Mac.', 'better-search-replace' ); ?></p>
 							</div>
 					</div>
 
@@ -70,7 +77,7 @@ if ( ! defined( 'BSR_PATH' ) ) exit;
 			<div class="panel">
 
 				<div class="panel-header">
-					<h3><?php _e( 'Additional Settings', 'better-search-replace' ); ?></h3>
+					<h3><?php esc_html_e( 'Additional Settings', 'better-search-replace' ); ?></h3>
 				</div>
 
 				<div class="panel-content settings additional-settings">
@@ -81,19 +88,19 @@ if ( ! defined( 'BSR_PATH' ) ) exit;
 						<input id="case_insensitive" type="checkbox" name="case_insensitive" <?php BSR_Admin::prefill_value( 'case_insensitive', 'checkbox' ); ?> />
 					</div>
 					<div class="col">
-						<label for="case_insensitive"><strong><?php _e( 'Case-Insensitive', 'better-search-replace' ); ?></strong></label>
-						<label for="case_insensitive"><span class="description"><?php _e( 'Searches are case-sensitive by default.', 'better-search-replace' ); ?></span></label>
+						<label for="case_insensitive"><strong><?php esc_html_e( 'Case-Insensitive', 'better-search-replace' ); ?></strong></label>
+						<label for="case_insensitive"><span class="description"><?php esc_html_e( 'Searches are case-sensitive by default.', 'better-search-replace' ); ?></span></label>
 					</div>
 				</label>
 
-	            <!--Replace GUIDs-->
+				 <!--Replace GUIDs-->
 				 <label for="replace_guids" class="row">
 					<div class="col">
 						<input id="replace_guids" type="checkbox" name="replace_guids" <?php BSR_Admin::prefill_value( 'replace_guids', 'checkbox' ); ?> />
 					</div>
 					<div class="col">
-					  <label for="replace_guids" class="replace_guids"><strong><?php _e( 'Replace GUIDs', 'better-search-replace' ); ?></strong><a href="https://wordpress.org/support/article/changing-the-site-url/#important-guid-note" target="_blank"><img src="<?php echo plugin_dir_url( __FILE__ ) . '../assets/svg/icon-help.svg'; ?>"></a></label>
-						<label for="replace_guids"><span class="description"><?php _e( 'If left unchecked, all database columns titled \'guid\' will be skipped.', 'better-search-replace' ); ?></span></label>
+					  <label for="replace_guids" class="replace_guids"><strong><?php esc_html_e( 'Replace GUIDs', 'better-search-replace' ); ?></strong><a href="<?php echo esc_url( $bsr_guid_doc ); ?>" target="_blank" rel="noopener noreferrer"><img src="<?php echo esc_url( $bsr_assets . 'icon-help.svg' ); ?>" alt=""></a></label>
+						<label for="replace_guids"><span class="description"><?php esc_html_e( 'If left unchecked, all database columns titled \'guid\' will be skipped.', 'better-search-replace' ); ?></span></label>
 					</div>
 				</label>
 
@@ -103,8 +110,8 @@ if ( ! defined( 'BSR_PATH' ) ) exit;
 						<input id="dry_run" type="checkbox" name="dry_run" checked />
 					</div>
 					<div class="col">
-						<label for="dry_run"><strong><?php _e( 'Run as dry run', 'better-search-replace' ); ?></strong></label></td>
-						<label for="dry_run"><span class="description"><?php _e( 'If checked, no changes will be made to the database, allowing you to check the results beforehand.', 'better-search-replace' ); ?></span></label>
+						<label for="dry_run"><strong><?php esc_html_e( 'Run as dry run', 'better-search-replace' ); ?></strong></label>
+						<label for="dry_run"><span class="description"><?php esc_html_e( 'If checked, no changes will be made to the database, allowing you to check the results beforehand.', 'better-search-replace' ); ?></span></label>
 					</div>
 				</label>
 
@@ -115,13 +122,13 @@ if ( ! defined( 'BSR_PATH' ) ) exit;
 			<div id="bsr-submit-wrap">
 				<?php wp_nonce_field( 'process_search_replace', 'bsr_nonce' ); ?>
 				<input type="hidden" name="action" value="bsr_process_search_replace" />
-				<button id="bsr-submit" type="submit" class="button button-primary button-lg"><?php _e( 'Run Search/Replace', 'better-search-replace' ); ?>
-					<img src="<?php echo plugin_dir_url( __FILE__ ) . '../assets/svg/icon-arrow.svg'; ?>">
+				<button id="bsr-submit" type="submit" class="button button-primary button-lg"><?php esc_html_e( 'Run Search/Replace', 'better-search-replace' ); ?>
+					<img src="<?php echo esc_url( $bsr_assets . 'icon-arrow.svg' ); ?>" alt="">
 				</button>
 			</div>
 		</div>
 
-	</div><!-- /.inside -->
+	</div>
 
 	<?php
 	if ( file_exists( BSR_PATH . 'templates/sidebar.php' ) ) {

--- a/templates/bsr-settings.php
+++ b/templates/bsr-settings.php
@@ -9,13 +9,18 @@
  * @subpackage Better_Search_Replace/templates
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Prevent direct/unauthorized access.
 if ( ! defined( 'BSR_PATH' ) ) exit;
 
-// Other settings.
-$page_size 	= get_option( 'bsr_page_size' ) ? absint( get_option( 'bsr_page_size' ) ) : 20000;
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template partial loaded in BSR admin context; variables are file scope, not WordPress globals.
+$page_size = get_option( 'bsr_page_size' ) ? absint( get_option( 'bsr_page_size' ) ) : 20000;
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 
- ?>
+?>
 
 <?php settings_fields( 'bsr_settings_fields' ); ?>
 
@@ -23,11 +28,10 @@ $page_size 	= get_option( 'bsr_page_size' ) ? absint( get_option( 'bsr_page_size
 
   <div class="inside">
 
-	<!--Settings Panel-->
 	<div class="panel">
 
 		<div class="panel-header">
-			 <h3><?php _e( 'Settings', 'better-search-replace' ); ?></h3>
+			 <h3><?php esc_html_e( 'Settings', 'better-search-replace' ); ?></h3>
 		</div>
 
 		<div class="panel-content settings">
@@ -36,11 +40,11 @@ $page_size 	= get_option( 'bsr_page_size' ) ? absint( get_option( 'bsr_page_size
 			<div class="row last-row">
 				<div class="input-text">
 					<div class="settings-header">
-						<label><strong><?php _e( 'Max Page Size', 'better-search-replace' ); ?></strong></label>
-						<span id="bsr-page-size-value"><?php echo absint( $page_size ); ?></span>
+						<label><strong><?php esc_html_e( 'Max Page Size', 'better-search-replace' ); ?></strong></label>
+						<span id="bsr-page-size-value"><?php echo esc_html( (string) absint( $page_size ) ); ?></span>
 					</div>
-					<input id="bsr_page_size" type="hidden" name="bsr_page_size" value="<?php echo $page_size; ?>" />
-					<p class="description"><?php _e( 'If you notice timeouts or are unable to backup/import the database, try decreasing this value.', 'better-search-replace' ); ?></p>
+					<input id="bsr_page_size" type="hidden" name="bsr_page_size" value="<?php echo esc_attr( (string) $page_size ); ?>" />
+					<p class="description"><?php esc_html_e( 'If you notice timeouts or are unable to backup/import the database, try decreasing this value.', 'better-search-replace' ); ?></p>
 					<div class="slider-wrapper">
 						<div id="bsr-page-size-slider" class="bsr-slider"></div>
 					</div>
@@ -61,5 +65,4 @@ $page_size 	= get_option( 'bsr_page_size' ) ? absint( get_option( 'bsr_page_size
 		include_once BSR_PATH . 'templates/sidebar.php';
 	}
 	?>
-  
 </div>

--- a/templates/sidebar.php
+++ b/templates/sidebar.php
@@ -1,32 +1,52 @@
+<?php
+/**
+ * Upgrade sidebar partial.
+ *
+ * @package Better_Search_Replace
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'BSR_PATH' ) ) {
+	exit;
+}
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Template partial loaded in BSR admin context; variables are file scope, not WordPress globals.
+$birds = plugin_dir_url( __FILE__ ) . '../assets/svg/mdb-birds.svg';
+$upgrade_href = 'https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=sidebar&utm_campaign=bsr-to-migrate';
+// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+
+?>
 <div class="upgrade-sidebar">
-	<img src="<?php echo plugin_dir_url( __FILE__ ) . '../assets/svg/mdb-birds.svg'; ?>">
+	<img src="<?php echo esc_url( $birds ); ?>" alt="">
 	<div class="content">
-		<h3><?php _e( 'Upgrade', 'better-search-replace' ); ?></h3>
-		<p><?php _e( 'Gain access to more database and migration features', 'better-search-replace' ); ?></p>
+		<h3><?php esc_html_e( 'Upgrade', 'better-search-replace' ); ?></h3>
+		<p><?php esc_html_e( 'Gain access to more database and migration features', 'better-search-replace' ); ?></p>
 
 		<ul>
 			<li>
-				<p><?php _e( 'Preview database changes before they are saved', 'better-search-replace' ); ?></p>
+				<p><?php esc_html_e( 'Preview database changes before they are saved', 'better-search-replace' ); ?></p>
 			</li>
 			<li>
-				<p><?php _e( 'Use regular expressions for complex string replacements', 'better-search-replace' ); ?></p>
+				<p><?php esc_html_e( 'Use regular expressions for complex string replacements', 'better-search-replace' ); ?></p>
 			</li>
 			<li>
-				<p><?php _e( 'Migrate full sites including themes, plugins, media, and database', 'better-search-replace' ); ?></p>
+				<p><?php esc_html_e( 'Migrate full sites including themes, plugins, media, and database', 'better-search-replace' ); ?></p>
 			</li>
 			<li>
-				<p><?php _e( 'Export and import WordPress databases', 'better-search-replace' ); ?></p>
+				<p><?php esc_html_e( 'Export and import WordPress databases', 'better-search-replace' ); ?></p>
 			</li>
 			<li>
-				<p><?php _e( 'Email support', 'better-search-replace' ); ?></p>
+				<p><?php esc_html_e( 'Email support', 'better-search-replace' ); ?></p>
 			</li>
 		</ul>
 
-		<p class="upgrade-offer-text"><?php _e( 'Get up to <span>50% off</span> your first year!', 'better-search-replace' ); ?></p>
+		<p class="upgrade-offer-text"><?php echo wp_kses_post( __( 'Get up to <span>50% off</span> your first year!', 'better-search-replace' ) ); ?></p>
 
 		<div class="button-row">
-			<a href="https://deliciousbrains.com/better-search-replace/upgrade/?utm_source=insideplugin&utm_medium=web&utm_content=sidebar&utm_campaign=bsr-to-migrate
-" class="button button-primary button-sm" target="_blank"><?php _e( 'Upgrade Now', 'better-search-replace' ); ?></a>
+			<a href="<?php echo esc_url( $upgrade_href ); ?>" class="button button-primary button-sm" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Upgrade Now', 'better-search-replace' ); ?></a>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
This PR resolves [DELI-1753](https://wpengine.atlassian.net/browse/DELI-1753).

## Description

Resolves 115 issues picked up in PCP testing:
Code | Count
-- | --
PluginCheck.Security.DirectDB.UnescapedDBParameter | 3
WordPress.DB.DirectDatabaseQuery.DirectQuery | 4
WordPress.DB.DirectDatabaseQuery.NoCaching | 4
WordPress.DB.PreparedSQL.InterpolatedNotPrepared | 4
WordPress.Security.EscapeOutput.OutputNotEscaped | 23
WordPress.Security.EscapeOutput.UnsafePrintingFunction | 36
WordPress.Security.NonceVerification.Missing | 2
WordPress.Security.NonceVerification.Recommended | 14
WordPress.Security.ValidatedSanitizedInput.InputNotSanitized | 3
WordPress.Security.ValidatedSanitizedInput.InputNotValidated | 3
WordPress.Security.ValidatedSanitizedInput.MissingUnslash | 5
missing_direct_file_access_protection | 8
WordPress.DB.PreparedSQL.NotPrepared | 2
Squiz.PHP.DiscouragedFunctions.Discouraged | 1
PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound | 1
WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet | 2

## Testing Checklist
- [ ] Does this PR require Multisite testing?
- [ ] Does this PR require CLI testing?

## Pre-review Checklist
- [x] Jira ticket and PR titles are correctly formatted.
- [x] Acceptance criteria from the Jira ticket have been satisfied.
- [ ] Changelog updated in readme(s) (if applicable).
- [ ] [Documentation issue](https://github.com/deliciousbrains/wp-migrate-db-pro/issues/new?assignees=&labels=Documentation&template=05-documentation.md&title=Documentation+of+X+should+%28not%29...) has been created (if docs need updated).
- [ ] Unit tests are included (if applicable).
- [x] Self-review of code changes has been completed.
- [x] Self-review of UX changes has been completed.
- [x] Review has been requested from team member(s).
- [x] GitHub Label has been selected for this PR.

[DELI-1753]: https://wpengine.atlassian.net/browse/DELI-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ