### PR TITLE
CONTRIBUTING.md and sonar-project.properties no longer get included in the bundled zip

### DIFF
--- a/build-cfg/better-search-replace/filter
+++ b/build-cfg/better-search-replace/filter
@@ -9,3 +9,4 @@
 - Makefile
 - node_modules
 - CONTRIBUTING.md
+- sonar-project.properties


### PR DESCRIPTION
This PR resolves [DELI-1814](https://wpengine.atlassian.net/browse/DELI-1814).

## Description
Added a line break to the end of the filter file to ensure all items are removed. 
I also added the `sonar-project.properties` to the filter

## Testing
1. Pull this branch
2. run `make clean-all && make` to clean the workspace.
3. run `make zip`.
4. extract the output zip and check for the `CONTRIBUTING.md` / `sonar-project.properties` files, and confirm they have been removed.

## Testing Checklist
- [ ] Does this PR require Multisite testing?
- [ ] Does this PR require CLI testing?

## Pre-review Checklist
- [x] Jira ticket and PR titles are correctly formatted.
- [x] Acceptance criteria from the Jira ticket have been satisfied.
- [ ] Changelog updated in readme(s) (if applicable).
- [ ] [Documentation issue](https://github.com/deliciousbrains/wp-migrate-db-pro/issues/new?assignees=&labels=Documentation&template=05-documentation.md&title=Documentation+of+X+should+%28not%29...) has been created (if docs need updated).
- [ ] Unit tests are included (if applicable).
- [x] Self-review of code changes has been completed.
- [x] Self-review of UX changes has been completed.
- [x] Review has been requested from team member(s).
- [x] GitHub Label has been selected for this PR.

[DELI-1814]: https://wpengine.atlassian.net/browse/DELI-1814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ