### PR TITLE
BSR now uses `prepare` statements instead of `mysql_escape_mimic` for SQL updates

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -98,6 +98,7 @@ More information on moving WordPress can be found [here](http://codex.wordpress.
 * New: Requires WordPress 6.2+
 * New: Requires PHP 8.1+
 * Fix: Core tables altered to have compound primary keys are now properly handled during search and replace
+* Fix: SQL injection vulnerability on multibyte charsets (GBK, Big5) has been resolved by replacing charset-unaware string escaping with `$wpdb->prepare()` (props to jonghan via Intigriti)
 * Fix: Improved security and stability
 
 = 1.4.10 - January 14, 2025 =

--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -260,6 +260,8 @@ class BSR_DB {
 			$current_row++;
 			$update_sql = array();
 			$where_sql  = array();
+			$update_values = array();
+			$where_values  = array();
 			$upd        = false;
 
 			foreach ( $columns as $column ) {
@@ -267,7 +269,9 @@ class BSR_DB {
 				$data_to_fix = $row[ $column ];
 
 				if ( in_array( $column, $primary_keys, true ) ) {
-					$where_sql[] = $column . ' = "' . $this->mysql_escape_mimic( $data_to_fix ) . '"';
+					$where_sql[] = '%i = %s';
+					$where_values[] = $column;
+					$where_values[] = $data_to_fix;
 					continue;
 				}
 
@@ -311,7 +315,9 @@ class BSR_DB {
 
 				// Something was changed
 				if ( $edited_data != $data_to_fix ) {
-					$update_sql[] = $column . ' = "' . $this->mysql_escape_mimic( $edited_data ) . '"';
+					$update_sql[] = '%i = %s';
+					$update_values[] = $column;
+					$update_values[] = $edited_data;
 					$upd          = true;
 					$table_report['change']++;
 				}
@@ -322,11 +328,12 @@ class BSR_DB {
 				// Don't do anything if a dry run
 			} elseif ( $upd && ! empty( $where_sql ) ) {
 				// If there are changes to make, run the query.
-				$t   = esc_sql( $table );
-				$sql = 'UPDATE `' . $t . '` SET ' . implode( ', ', $update_sql ) . ' WHERE ' . implode( ' AND ', array_filter( $where_sql ) );
-				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Dynamic UPDATE: table allowlisted; columns from DESCRIBE; values escaped via mysql_escape_mimic().
-				$result = $wpdb->query( $sql );
-				// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared,PluginCheck.Security.DirectDB.UnescapedDBParameter,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+				$sql_template = 'UPDATE %i SET ' . implode( ', ', $update_sql ) . ' WHERE ' . implode( ' AND ', array_filter( $where_sql ) );
+				$prepare_args = array_merge( array( $sql_template, $table ), $update_values, $where_values );
+
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Dynamic UPDATE: table and columns allowlisted; values passed through $wpdb->prepare().
+				$result = $wpdb->query( call_user_func_array( array( $wpdb, 'prepare' ), $prepare_args ) );
+				// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
 
 				if ( ! $result ) {
 					$table_report['errors'][] = sprintf(
@@ -460,23 +467,6 @@ class BSR_DB {
 		return false;
 	}
 
-	/**
-	 * Mimics the mysql_real_escape_string function. Adapted from a post by 'feedr' on php.net.
-	 * @link   http://php.net/manual/en/function.mysql-real-escape-string.php#101248
-	 * @access public
-	 * @param  string $input The string to escape.
-	 * @return string
-	 */
-	public function mysql_escape_mimic( $input ) {
-	    if ( is_array( $input ) ) {
-	        return array_map( __METHOD__, $input );
-	    }
-	    if ( ! empty( $input ) && is_string( $input ) ) {
-	        return str_replace( array( '\\', "\0", "\n", "\r", "'", '"', "\x1a" ), array( '\\\\', '\\0', '\\n', '\\r', "\\'", '\\"', '\\Z' ), $input );
-	    }
-
-	    return $input;
-	}
 
 	/**
 	 * Return unserialized object or array

--- a/includes/class-bsr-db.php
+++ b/includes/class-bsr-db.php
@@ -258,18 +258,18 @@ class BSR_DB {
 
 		foreach ( $data as $row ) {
 			$current_row++;
-			$update_sql = array();
-			$where_sql  = array();
+			$update_sql    = array();
+			$where_sql     = array();
 			$update_values = array();
 			$where_values  = array();
-			$upd        = false;
+			$upd           = false;
 
 			foreach ( $columns as $column ) {
 
 				$data_to_fix = $row[ $column ];
 
 				if ( in_array( $column, $primary_keys, true ) ) {
-					$where_sql[] = '%i = %s';
+					$where_sql[]    = '%i = %s';
 					$where_values[] = $column;
 					$where_values[] = $data_to_fix;
 					continue;
@@ -315,10 +315,10 @@ class BSR_DB {
 
 				// Something was changed
 				if ( $edited_data != $data_to_fix ) {
-					$update_sql[] = '%i = %s';
+					$update_sql[]    = '%i = %s';
 					$update_values[] = $column;
 					$update_values[] = $edited_data;
-					$upd          = true;
+					$upd             = true;
 					$table_report['change']++;
 				}
 			}


### PR DESCRIPTION
This PR resolves [DELI-2231](https://wpengine.atlassian.net/browse/DELI-2231).

## Description

- Replace charset-unaware string escaping with `$wpdb->prepare()`
- Remove vulnerable `mysql_escape_mimic()` function entirely
- Use `%i` and `%s` placeholders for identifiers and values in `UPDATE` queries
- Fixes SQL injection vulnerability on multibyte charsets (GBK, Big5)

## Testing Checklist
- [ ] Does this PR require Multisite testing?
- [ ] Does this PR require CLI testing?

## Pre-review Checklist
- [x] Jira ticket and PR titles are correctly formatted.
- [x] Acceptance criteria from the Jira ticket have been satisfied.
- [ ] Changelog updated in readme(s) (if applicable).
- [ ] [Documentation issue](https://github.com/deliciousbrains/wp-migrate-db-pro/issues/new?assignees=&labels=Documentation&template=05-documentation.md&title=Documentation+of+X+should+%28not%29...) has been created (if docs need updated).
- [ ] Unit tests are included (if applicable).
- [x] Self-review of code changes has been completed.
- [x] Self-review of UX changes has been completed.
- [x] Review has been requested from team member(s).
- [x] GitHub Label has been selected for this PR.

[DELI-2231]: https://wpengine.atlassian.net/browse/DELI-2231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ