### PR TITLE
BSR now has hardened version checks for WP 6.2+ and PHP 8.1+

### DIFF
--- a/better-search-replace.php
+++ b/better-search-replace.php
@@ -14,6 +14,8 @@
  * Plugin URI:        https://bettersearchreplace.com
  * Description:       A small plugin for running a search/replace on your WordPress database.
  * Version:           1.4.11
+ * Requires at least: 6.2
+ * Requires PHP:      8.1
  * Author:            WP Engine
  * Author URI:        https://bettersearchreplace.com
  * Update URI:        false
@@ -63,6 +65,87 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	define( 'BSR_NAME', 'Better Search Replace' );
 
 	/**
+	 * Check if WordPress version meets minimum requirement.
+	 *
+	 * @since 1.4.11
+	 * @return bool True if WordPress version is sufficient, false otherwise.
+	 */
+	function bsr_check_wp_version() {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '6.2', '<' ) ) {
+			add_action( 'admin_notices', 'bsr_wp_version_notice' );
+			add_action( 'network_admin_notices', 'bsr_wp_version_notice' );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if PHP version meets minimum requirement.
+	 *
+	 * @since 1.4.11
+	 * @return bool True if PHP version is sufficient, false otherwise.
+	 */
+	function bsr_check_php_version() {
+		if ( version_compare( PHP_VERSION, '8.1', '<' ) ) {
+			add_action( 'admin_notices', 'bsr_php_version_notice' );
+			add_action( 'network_admin_notices', 'bsr_php_version_notice' );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Display admin notice for insufficient WordPress version.
+	 *
+	 * @since 1.4.11
+	 */
+	function bsr_wp_version_notice() {
+		global $wp_version;
+		?>
+		<div class="notice notice-error">
+			<p>
+				<?php
+				printf(
+					/* translators: 1: Plugin name, 2: Required WordPress version, 3: Current WordPress version */
+					esc_html__( '%1$s requires WordPress %2$s or higher. You are currently running WordPress %3$s. Please upgrade WordPress to activate this plugin.', 'better-search-replace' ),
+					'<strong>' . esc_html( BSR_NAME ) . '</strong>',
+					'<strong>6.2</strong>',
+					'<strong>' . esc_html( $wp_version ) . '</strong>'
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Display admin notice for insufficient PHP version.
+	 *
+	 * @since 1.4.11
+	 */
+	function bsr_php_version_notice() {
+		?>
+		<div class="notice notice-error">
+			<p>
+				<?php
+				printf(
+					/* translators: 1: Plugin name, 2: Required PHP version, 3: Current PHP version */
+					esc_html__( '%1$s requires PHP %2$s or higher. You are currently running PHP %3$s. Please contact your web host to upgrade PHP to activate this plugin.', 'better-search-replace' ),
+					'<strong>' . esc_html( BSR_NAME ) . '</strong>',
+					'<strong>8.1</strong>',
+					'<strong>' . esc_html( PHP_VERSION ) . '</strong>'
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Begins execution of the plugin.
 	 *
 	 * Since everything within the plugin is registered via hooks,
@@ -73,6 +156,11 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	 */
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Bootstrap entry; guarded by function_exists in bootstrap.
 	function run_better_search_replace() {
+		// Check version requirements before loading the plugin.
+		if ( ! bsr_check_wp_version() || ! bsr_check_php_version() ) {
+			return;
+		}
+
 		if ( bsr_enabled_for_user() ) {
 			/**
 			 * The core plugin class that is used to define internationalization,

--- a/better-search-replace.php
+++ b/better-search-replace.php
@@ -65,6 +65,28 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	define( 'BSR_NAME', 'Better Search Replace' );
 
 	/**
+	 * Get plugin data from plugin header.
+	 *
+	 * @param string $header
+	 *
+	 * @return string
+	 * @since 1.4.11
+	 */
+	function bsr_get_plugin_data( $header ) {
+		$data = get_file_data( __FILE__, array(
+			'Name'        => 'Plugin Name',
+			'RequiresWP'  => 'Requires at least',
+			'RequiresPHP' => 'Requires PHP',
+		), 'plugin' );
+
+		if ( empty( $data[ $header ] ) ) {
+			return '';
+		}
+
+		return $data[ $header ];
+	}
+
+	/**
 	 * Check if WordPress version meets minimum requirement.
 	 *
 	 * @since 1.4.11
@@ -73,9 +95,10 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	function bsr_check_wp_version() {
 		global $wp_version;
 
-		if ( version_compare( $wp_version, '6.2', '<' ) ) {
+		if ( version_compare( $wp_version, bsr_get_plugin_data( 'RequiresWP' ) ) === -1 ) {
 			add_action( 'admin_notices', 'bsr_wp_version_notice' );
 			add_action( 'network_admin_notices', 'bsr_wp_version_notice' );
+
 			return false;
 		}
 
@@ -89,9 +112,10 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	 * @return bool True if PHP version is sufficient, false otherwise.
 	 */
 	function bsr_check_php_version() {
-		if ( version_compare( PHP_VERSION, '8.1', '<' ) ) {
+		if ( version_compare( PHP_VERSION, bsr_get_plugin_data( 'RequiresPHP' ) ) === -1 ) {
 			add_action( 'admin_notices', 'bsr_php_version_notice' );
 			add_action( 'network_admin_notices', 'bsr_php_version_notice' );
+
 			return false;
 		}
 
@@ -109,12 +133,17 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 		<div class="notice notice-error">
 			<p>
 				<?php
-				printf(
+				echo wp_kses_post(
+					sprintf(
 					/* translators: 1: Plugin name, 2: Required WordPress version, 3: Current WordPress version */
-					esc_html__( '%1$s requires WordPress %2$s or higher. You are currently running WordPress %3$s. Please upgrade WordPress to activate this plugin.', 'better-search-replace' ),
-					'<strong>' . esc_html( BSR_NAME ) . '</strong>',
-					'<strong>6.2</strong>',
-					'<strong>' . esc_html( $wp_version ) . '</strong>'
+						__(
+							'<strong>%1$s</strong> requires WordPress <strong>%2$s</strong> or higher. You are currently running WordPress <strong>%3$s</strong>. Please upgrade WordPress to activate this plugin.',
+							'better-search-replace'
+						),
+						bsr_get_plugin_data( 'Name' ),
+						bsr_get_plugin_data( 'RequiresWP' ),
+						esc_html( $wp_version )
+					)
 				);
 				?>
 			</p>
@@ -132,12 +161,17 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 		<div class="notice notice-error">
 			<p>
 				<?php
-				printf(
+				echo wp_kses_post(
+					sprintf(
 					/* translators: 1: Plugin name, 2: Required PHP version, 3: Current PHP version */
-					esc_html__( '%1$s requires PHP %2$s or higher. You are currently running PHP %3$s. Please contact your web host to upgrade PHP to activate this plugin.', 'better-search-replace' ),
-					'<strong>' . esc_html( BSR_NAME ) . '</strong>',
-					'<strong>8.1</strong>',
-					'<strong>' . esc_html( PHP_VERSION ) . '</strong>'
+						__(
+							'<strong>%1$s</strong> requires PHP <strong>%2$s</strong> or higher. You are currently running PHP <strong>%3$s</strong>. Please contact your web host to upgrade PHP to activate this plugin.',
+							'better-search-replace'
+						),
+						bsr_get_plugin_data( 'Name' ),
+						bsr_get_plugin_data( 'RequiresPHP' ),
+						esc_html( PHP_VERSION )
+					)
 				);
 				?>
 			</p>

--- a/better-search-replace.php
+++ b/better-search-replace.php
@@ -191,7 +191,7 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Bootstrap entry; guarded by function_exists in bootstrap.
 	function run_better_search_replace() {
 		// Check version requirements before loading the plugin.
-		if ( ! bsr_check_wp_version() || ! bsr_check_php_version() ) {
+		if ( ! bsr_check_php_version() || ! bsr_check_wp_version() ) {
 			return;
 		}
 

--- a/better-search-replace.php
+++ b/better-search-replace.php
@@ -89,8 +89,8 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	/**
 	 * Check if WordPress version meets minimum requirement.
 	 *
-	 * @since 1.4.11
 	 * @return bool True if WordPress version is sufficient, false otherwise.
+	 * @since 1.4.11
 	 */
 	function bsr_check_wp_version() {
 		global $wp_version;
@@ -108,8 +108,8 @@ if ( ! function_exists( 'run_better_search_replace' ) ) {
 	/**
 	 * Check if PHP version meets minimum requirement.
 	 *
-	 * @since 1.4.11
 	 * @return bool True if PHP version is sufficient, false otherwise.
+	 * @since 1.4.11
 	 */
 	function bsr_check_php_version() {
 		if ( version_compare( PHP_VERSION, bsr_get_plugin_data( 'RequiresPHP' ) ) === -1 ) {

--- a/languages/better-search-replace.pot
+++ b/languages/better-search-replace.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Better Search Replace 1.4.11\n"
 "Report-Msgid-Bugs-To: "
 "http://wordpress.org/support/plugin/better-search-replace\n"
-"POT-Creation-Date: 2026-06-04 11:09:28+00:00\n"
+"POT-Creation-Date: 2026-06-24 09:07:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,6 +24,23 @@ msgstr ""
 "X-Poedit-Bookmarks: \n"
 "X-Textdomain-Support: yes\n"
 "X-Generator: grunt-wp-i18n 1.0.4\n"
+
+#: better-search-replace.php:139
+#. translators: 1: Plugin name, 2: Required WordPress version, 3: Current
+#. WordPress version
+msgid ""
+"<strong>%1$s</strong> requires WordPress <strong>%2$s</strong> or higher. "
+"You are currently running WordPress <strong>%3$s</strong>. Please upgrade "
+"WordPress to activate this plugin."
+msgstr ""
+
+#: better-search-replace.php:167
+#. translators: 1: Plugin name, 2: Required PHP version, 3: Current PHP version
+msgid ""
+"<strong>%1$s</strong> requires PHP <strong>%2$s</strong> or higher. You are "
+"currently running PHP <strong>%3$s</strong>. Please contact your web host "
+"to upgrade PHP to activate this plugin."
+msgstr ""
 
 #: includes/class-bsr-admin.php:76
 msgid "No search string was defined, please enter a URL or string to search for."


### PR DESCRIPTION
This PR resolves [DELI-2228](https://wpengine.atlassian.net/browse/DELI-2228).

## Description

- Add 'Requires at least: 6.2' and 'Requires PHP: 8.1' plugin headers
- Add runtime version checks to prevent plugin loading on incompatible systems
- Display clear admin error notices when requirements not met
- Soft deactivation prevents SQL errors from %i placeholder usage on WP < 6.2
- Network admin support for multisite installations

## Testing Checklist
- [ ] Does this PR require Multisite testing?
- [ ] Does this PR require CLI testing?

## Pre-review Checklist
- [x] Jira ticket and PR titles are correctly formatted.
- [x] Acceptance criteria from the Jira ticket have been satisfied.
- [ ] Changelog updated in readme(s) (if applicable).
- [ ] [Documentation issue](https://github.com/deliciousbrains/wp-migrate-db-pro/issues/new?assignees=&labels=Documentation&template=05-documentation.md&title=Documentation+of+X+should+%28not%29...) has been created (if docs need updated).
- [ ] Unit tests are included (if applicable).
- [x] Self-review of code changes has been completed.
- [x] Self-review of UX changes has been completed.
- [x] Review has been requested from team member(s).
- [x] GitHub Label has been selected for this PR.

[DELI-2228]: https://wpengine.atlassian.net/browse/DELI-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ